### PR TITLE
Getting those MSVC Build Scripts Rolling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cl-sys"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["opencl", "gpu", "gpgpu"]
 license = "MIT/Apache-2.0"
 exclude = ["target/*", "bak/*"]
+build = "build.rs"
 
 [dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
 additional terms or conditions.
+
+##### BROKEN ON WINDOWS MSVC
+
+Download your Vendors OpenCL SDK:
+
+[AMD](developer.amd.com/tools-and-sdks/opencl-zone/amd-accelerated-parallel-processing-app-sdk/)
+
+Intel will make you register an account with them FYI. 
+[Intel](https://software.intel.com/en-us/intel-opencl)
+
+[Nvidia](https://developer.nvidia.com/opencl)

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+
+/*
+ * This build script needs your help!
+ *
+ * To get cl-sys working on _all_ platforms will be a group effort.
+ * Namely GPU's are ungodly expensive. I don't know where _every_
+ * OpenCL.lib file is installed to on Windows.
+ *
+ * So if you want to use this library on windows. Please patch in your
+ * OpenCL.lib location. 
+ *
+ * You will need to install the OpenCL SDK for your _vendor_
+ *
+ * In the future we _may_ want to add feature flag to determine _which_ vendor's OpenCL you are
+ * using.
+ */
+
+fn main() {
+    
+    //This is is the build script related to windows
+    #[cfg(all(target_os= "windows", target_arch="x86", target_pointer_width="32"))]
+    {
+
+        //This is where the AMD OpenCL.lib file is located for RX480's
+        println!("cargo:rustc-link-search={}",r"C:\Program Files (x86)\AMD APP SDK\3.0\lib\x86\");
+    }
+    #[cfg(all(target_os= "windows", target_arch="x86_64", target_pointer_width="64"))]
+    {
+
+        println!("cargo:rustc-link-search={}",r"C:\Program Files (x86)\AMD APP SDK\3.0\lib\x86_64");
+    }
+
+}


### PR DESCRIPTION
See: https://github.com/cogciprocate/ocl/issues/28

This allows the crate to compile successfully on Windows10 x64 MSVC (should handle x86 too). I have an RX480, so I'm unsure how _other_ AMD cards will handle their OpenCL SDK. But seeing as AMD only offer 1 OpenCL SDK download I think they should be consistent. 

This weekend I should be getting my Nvidia Card back (was attempting to sell it on ebay). I'll throw its OpenCL SDK in also.

Should we add feature flag for which backend is being used? As it is likely possible the developer has an Intel, and Nvidia/AMD SDK installed at the same time.

:.:.:

Should the buffer_copy tests take >60 seconds?