### PR TITLE
Fixed compilation error with mesa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ opencl_version_1_2 = []
 opencl_version_2_0 = []
 opencl_version_2_1 = []
 opencl_version_2_2 = []
+opencl_vendor_mesa = []
 
 # `opencl_version_1_1` is unused, disabling it has no effect.
 default = ["opencl_version_1_1", "opencl_version_1_2"]

--- a/src/cl_gl_h.rs
+++ b/src/cl_gl_h.rs
@@ -93,6 +93,7 @@ extern "system" {
                                       renderbuffer: cl_GLuint,
                                       errcode_ret: *mut cl_int) -> cl_mem;
 
+    #[cfg(not(feature="opencl_vendor_mesa"))]
     pub fn clEnqueueAcquireGLObjects(command_queue: cl_command_queue,
                                      num_objects: cl_uint,
                                      mem_objects: *const cl_mem,
@@ -100,6 +101,7 @@ extern "system" {
                                      event_wait_list: *const cl_event,
                                      event: *mut cl_event) -> cl_int;
 
+    #[cfg(not(feature="opencl_vendor_mesa"))]
     pub fn clEnqueueReleaseGLObjects(command_queue: cl_command_queue,
                                      num_objects: cl_uint,
                                      mem_objects: *const cl_mem,

--- a/src/cl_gl_h.rs
+++ b/src/cl_gl_h.rs
@@ -3,10 +3,12 @@
 #![allow(non_camel_case_types, dead_code, unused_variables, improper_ctypes, non_upper_case_globals)]
 
 use libc::{c_void, size_t};
-use platform_h::{cl_GLuint, cl_GLint, cl_GLenum};
+use cl_h::{cl_context_properties, cl_int, cl_uint};
 
-use cl_h::{cl_context, cl_context_properties, cl_mem_flags, cl_command_queue,
-    cl_int, cl_uint, cl_mem, cl_event};
+#[cfg(not(feature="opencl_vendor_mesa"))]
+use platform_h::{cl_GLuint, cl_GLint, cl_GLenum};
+#[cfg(not(feature="opencl_vendor_mesa"))]
+use cl_h::{cl_context, cl_mem_flags, cl_mem, cl_command_queue, cl_event};
 
 pub type cl_gl_object_type      = cl_uint;
 pub type cl_gl_texture_info     = cl_uint;
@@ -65,6 +67,7 @@ pub type clGetGLContextInfoKHR_fn = *mut extern "system" fn(
 #[cfg_attr(target_os = "macos", link(name = "OpenCL", kind = "framework"))]
 #[cfg_attr(target_os = "windows", link(name = "OpenCL"))]
 #[cfg_attr(not(target_os = "macos"), link(name = "OpenCL"))]
+#[cfg(not(feature="opencl_vendor_mesa"))]  // Mesa does not support context sharing with OpenGL.
 extern "system" {
     pub fn clCreateFromGLBuffer(context: cl_context,
                                 flags: cl_mem_flags,
@@ -93,7 +96,6 @@ extern "system" {
                                       renderbuffer: cl_GLuint,
                                       errcode_ret: *mut cl_int) -> cl_mem;
 
-    #[cfg(not(feature="opencl_vendor_mesa"))]
     pub fn clEnqueueAcquireGLObjects(command_queue: cl_command_queue,
                                      num_objects: cl_uint,
                                      mem_objects: *const cl_mem,
@@ -101,7 +103,6 @@ extern "system" {
                                      event_wait_list: *const cl_event,
                                      event: *mut cl_event) -> cl_int;
 
-    #[cfg(not(feature="opencl_vendor_mesa"))]
     pub fn clEnqueueReleaseGLObjects(command_queue: cl_command_queue,
                                      num_objects: cl_uint,
                                      mem_objects: *const cl_mem,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,15 +39,11 @@ pub use self::cl_gl_h::{CL_GL_OBJECT_BUFFER, CL_GL_OBJECT_TEXTURE2D, CL_GL_OBJEC
     CL_CURRENT_DEVICE_FOR_GL_CONTEXT_KHR, CL_DEVICES_FOR_GL_CONTEXT_KHR, CL_GL_CONTEXT_KHR,
     CL_EGL_DISPLAY_KHR, CL_GLX_DISPLAY_KHR, CL_WGL_HDC_KHR, CL_CGL_SHAREGROUP_KHR};
 
+#[cfg(not(feature="opencl_vendor_mesa"))]
 pub use self::cl_gl_h::{clGetGLContextInfoKHR_fn, clCreateFromGLBuffer, clCreateFromGLTexture,
     clGetGLObjectInfo, clGetGLTextureInfo, clCreateFromGLRenderbuffer,
-    clCreateFromGLTexture2D,
+    clEnqueueAcquireGLObjects, clEnqueueReleaseGLObjects, clCreateFromGLTexture2D,
     clCreateFromGLTexture3D, clGetGLContextInfoKHR};
-
-#[cfg(not(feature="opencl_vendor_mesa"))] 
-pub use self::cl_gl_h::{
-    clEnqueueAcquireGLObjects,
-    clEnqueueReleaseGLObjects };
 
 pub use self::cl_egl_h::{CLeglImageKHR, CLeglDisplayKHR, CLeglSyncKHR, cl_egl_image_properties_khr};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,13 @@ pub use self::cl_gl_h::{CL_GL_OBJECT_BUFFER, CL_GL_OBJECT_TEXTURE2D, CL_GL_OBJEC
 
 pub use self::cl_gl_h::{clGetGLContextInfoKHR_fn, clCreateFromGLBuffer, clCreateFromGLTexture,
     clGetGLObjectInfo, clGetGLTextureInfo, clCreateFromGLRenderbuffer,
-    clEnqueueAcquireGLObjects, clEnqueueReleaseGLObjects, clCreateFromGLTexture2D,
+    clCreateFromGLTexture2D,
     clCreateFromGLTexture3D, clGetGLContextInfoKHR};
+
+#[cfg(not(feature="opencl_vendor_mesa"))] 
+pub use self::cl_gl_h::{
+    clEnqueueAcquireGLObjects,
+    clEnqueueReleaseGLObjects };
 
 pub use self::cl_egl_h::{CLeglImageKHR, CLeglDisplayKHR, CLeglSyncKHR, cl_egl_image_properties_khr};
 


### PR DESCRIPTION
Excluded functions related to context sharing OpenGL. 

Currently Mesa does not support context sharing with OpenGL. The related functions are missing from the Mesa library and will cause linker errors if referenced.
    
Constants and structs related to the context sharing with OpenGL still included. Reasoning: Easier to develop libraries / applications that in some configurations require OpenGL context sharing. With the constants and structs included, there is potentially less functionality that the library / application needs to exclude with Mesa.